### PR TITLE
Fix phantom horizontal overflow bug

### DIFF
--- a/Assets/CSS/main.css
+++ b/Assets/CSS/main.css
@@ -130,7 +130,7 @@ nav .right .btn{
 
 header{
     height: 65vh;
-    width: 100vw;
+    width: 100%;
     background: -webkit-linear-gradient( rgba(44, 62, 80, 0.55), rgba(44, 62, 80, 0.55)), url("../Graphics/header.jpeg");
     background: linear-gradient( rgba(44, 62, 80, 0.55), rgba(44, 62, 80, 0.55)), url("../Graphics/header.jpeg");
     background-size: cover;


### PR DESCRIPTION
Setting width of the header class to 100vh causes a horizontal overflow, allowing users to horizontally scroll into white space. This seems to be a bug which is addressed in this PR.

Things done:
- Change width from 100vh to 100%

Also hello Techmasters! Lovely PACTF ya'll putting on.